### PR TITLE
docs: add Docker deployment guide and compose file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.2.1] - 2026-03-15
+
+- Added docker-compose.yaml for lightweight nginx:alpine deployment
+- Added Docker deployment guide to README
+- Traefik reverse proxy labels included
+- Portainer stack instructions
+- Resource limits and health check configured
+
 ## [0.2.0] - 2026-03-15
 
 - Mobile-responsive layout for all tabs

--- a/Docker/README.md
+++ b/Docker/README.md
@@ -1,0 +1,68 @@
+# Docker Deployment
+Deploy the homelab network map as a lightweight container using `nginx:alpine`.
+
+## Prerequisites
+- Docker and Docker Compose installed
+- The `dist/` folder from a production build (`npm run build`)
+
+## Quick Start
+1. Build the project:
+
+```bash
+npm install
+npm run build
+```
+
+2. Start the container:
+
+```bash
+docker compose up -d
+```
+
+The map is now served on port `80` inside the container.
+
+## Standalone (No Reverse Proxy)
+If you're not running Traefik or any reverse proxy, uncomment the ports section in `docker-compose.yaml`:
+
+```yaml
+ports:
+- 8585:80
+```
+
+Then access the map at `http://localhost:8585`.
+
+## Traefik Reverse Proxy
+The compose file includes Traefik labels out of the box. Update the `Host` rule to match your domain:
+
+```yaml
+- traefik.http.routers.homelab-map-secure.rule=Host(`homelab-map.yourdomain.com`)
+```
+
+Make sure the `proxy` network exists and your Traefik instance is on the same network:
+
+```bash
+docker network create proxy
+```
+
+## Portainer Stack
+1. In Portainer, go to **Stacks → Add stack**
+2. Paste the contents of `docker-compose.yaml`
+3. Set the stack name to `homelab-map`
+4. Make sure the `dist/` folder path is correct under volumes
+5. Deploy
+
+## Resource Limits
+The container is capped at **500MB RAM** and **1 CPU core** - more than enough for serving static files with nginx.
+
+## Health Check
+A built-in health check runs every 30 seconds:
+
+```
+wget -q --spider http://localhost || exit 1
+```
+
+Check container health with:
+
+```bash
+docker inspect --format='{{.State.Health.Status}}' homelab-map
+```

--- a/Docker/docker-compose.yaml
+++ b/Docker/docker-compose.yaml
@@ -1,0 +1,41 @@
+services:
+  homelab-map:
+    image: nginx:alpine
+    container_name: homelab-map
+   # ports:
+   #   - 8585:80
+    volumes:
+      - ./dist:/usr/share/nginx/html:ro
+    deploy:
+      resources:
+        limits:
+          memory: 500m
+          cpus: "1.0"
+    healthcheck:
+      test:
+        - CMD-SHELL
+        - wget -q --spider http://localhost || exit 1
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
+    restart: unless-stopped
+    logging:
+      driver: json-file
+      options:
+        max-size: 10m
+        max-file: "3"
+    networks:
+      - proxy
+    labels:
+      - traefik.enable=true
+      - traefik.http.routers.homelab-map-secure.entrypoints=https
+      - traefik.http.routers.homelab-map-secure.rule=Host(`homelab-map.local.YOUR_DOMAIN`)
+      - traefik.http.routers.homelab-map-secure.tls=true
+      - traefik.http.routers.homelab-map-secure.tls.certresolver=cloudflare
+      - traefik.http.routers.homelab-map-secure.service=homelab-map
+      - traefik.http.services.homelab-map.loadbalancer.server.port=80
+
+networks:
+  proxy:
+    external: true


### PR DESCRIPTION
## Summary
Adds a `docker/` directory so users can self-host the homelab map quickly via Docker.

## Changes

### Docker
- `docker-compose.yaml` - nginx:alpine serving the built `dist/` folder
- `docker/README.md` - step-by-step deployment instructions